### PR TITLE
internal/bytealg: fix amd64 cpu feature detection

### DIFF
--- a/internal/bytealg/count_amd64.s
+++ b/internal/bytealg/count_amd64.s
@@ -11,7 +11,7 @@
 
 TEXT ·Count(SB), NOSPLIT, $0-40
 #ifndef hasPOPCNT
-	CMPB internal∕cpu·X86+const_offsetX86HasPOPCNT(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasPOPCNT(SB), $1
 	JEQ  2(PC)
 	JMP  ·countGeneric(SB)
 
@@ -38,7 +38,7 @@ count:
 
 TEXT ·CountString(SB), NOSPLIT, $0-32
 #ifndef hasPOPCNT
-	CMPB internal∕cpu·X86+const_offsetX86HasPOPCNT(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasPOPCNT(SB), $1
 	JEQ  2(PC)
 	JMP  ·countGenericString(SB)
 
@@ -227,7 +227,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif
@@ -453,7 +453,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif

--- a/internal/bytealg/count_go122_amd64.s
+++ b/internal/bytealg/count_go122_amd64.s
@@ -11,7 +11,7 @@
 
 TEXT ·Count(SB), NOSPLIT, $0-40
 #ifndef hasPOPCNT
-	CMPB internal∕cpu·X86+const_offsetX86HasPOPCNT(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasPOPCNT(SB), $1
 	JEQ  2(PC)
 	JMP  ·countGeneric(SB)
 
@@ -38,7 +38,7 @@ count:
 
 TEXT ·CountString(SB), NOSPLIT, $0-32
 #ifndef hasPOPCNT
-	CMPB internal∕cpu·X86+const_offsetX86HasPOPCNT(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasPOPCNT(SB), $1
 	JEQ  2(PC)
 	JMP  ·countGenericString(SB)
 
@@ -228,7 +228,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif
@@ -456,7 +456,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif

--- a/internal/bytealg/index_non_ascii_amd64.s
+++ b/internal/bytealg/index_non_ascii_amd64.s
@@ -122,7 +122,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif

--- a/internal/bytealg/index_non_ascii_go122_amd64.s
+++ b/internal/bytealg/index_non_ascii_go122_amd64.s
@@ -124,7 +124,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif

--- a/internal/bytealg/indexbyte_amd64.s
+++ b/internal/bytealg/indexbyte_amd64.s
@@ -173,7 +173,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif
@@ -317,7 +317,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif

--- a/internal/bytealg/indexbyte_go122_amd64.s
+++ b/internal/bytealg/indexbyte_go122_amd64.s
@@ -175,7 +175,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif
@@ -323,7 +323,7 @@ endofpage:
 
 avx2:
 #ifndef hasAVX2
-	CMPB internal∕cpu·X86+const_offsetX86HasAVX2(SB), $1
+	CMPB golang·org∕x∕sys∕cpu·X86+const_offsetX86HasAVX2(SB), $1
 	JNE  sse
 
 #endif


### PR DESCRIPTION
This changes bytealg to actually use the golang.org/x/sys/cpu package to detect CPU features, which resolves an issue where POPCNT was not detected when GOAMD=v1.